### PR TITLE
Improve Hugging Face video inference handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Create a `.env.local` file and add the necessary environment variables:
 ```
 NEXT_PUBLIC_SOLANA_RPC_HOST=https://api.mainnet-beta.solana.com
 NEXT_PUBLIC_ENDPOINT=your-api-endpoint
+HUGGINGFACE_API_TOKEN=your-huggingface-token
 ```
 
 4. **Start Development Server**
@@ -111,8 +112,8 @@ The application will run at `http://localhost:3000`.
 
 ## Usage Guide
 
-1. **Connect Wallet**: Click the "Connect Wallet" button in the navigation bar and select Phantom wallet to connect.
-2. **Create Video**: Visit the creation page, enter a descriptive prompt, and generate an AI video.
+1. **Connect Wallet (Optional)**: Click the "Connect Wallet" button in the navigation bar and select Phantom wallet if you want to access blockchain-powered features.
+2. **Create Video**: Visit the creation page, enter a descriptive prompt, choose one of the listed Hugging Face long-form video models, and generate an AI video without needing a wallet connection.
 3. **Mint NFT**: Mint an NFT for your video work, setting quantity and price.
 4. **Browse Marketplace**: Explore NFT works by other creators and purchase content of interest.
 5. **Participate in DAO**: Use your tokens to participate in platform governance voting.

--- a/src/api/videoGeneration.ts
+++ b/src/api/videoGeneration.ts
@@ -1,238 +1,68 @@
-import axios from 'axios';
-
-// Video generation parameters interface
 export interface VideoGenerationParams {
   prompt: string;
-  referenceImage?: string; // base64 encoded image
-  style: string;
-  duration: number; // in seconds
+  modelId: string;
+  duration: number;
   resolution: '480p' | '720p' | '1080p';
   fps: number;
 }
 
-// Generation status interface
-export interface GenerationStatus {
-  id: string;
-  status: 'pending' | 'processing' | 'completed' | 'failed';
-  progress: number; // 0-100
-  result?: string; // URL to the completed video
-  error?: string;
+export interface VideoGenerationResult {
+  videoUrl: string;
+  modelId: string;
+  duration?: number;
 }
 
-// Mock video database - mapping styles to predefined video URLs
-const STYLE_VIDEO_URLS: Record<string, string[]> = {
-  'realistic': [
-    'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4',
-    'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ElephantsDream.mp4',
-    'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerBlazes.mp4',
-    'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerEscapes.mp4',
-  ],
-  'anime': [
-    'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerFun.mp4',
-    'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4',
-    'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerMeltdowns.mp4',
-    'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/Sintel.mp4',
-  ],
-  'cinematic': [
-    'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/SubaruOutbackOnStreetAndDirt.mp4',
-    'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/TearsOfSteel.mp4',
-    'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/VolkswagenGTIReview.mp4',
-    'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/WeAreGoingOnBullrun.mp4',
-  ],
-  '3d': [
-    'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/WhatCarCanYouGetForAGrand.mp4',
-    'https://storage.coverr.co/videos/zFBCJnA5qe01oZ4zXATHqVzA9JYEDGgwE?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhcHBJZCI6IjIzQ0I1QURCMjc3QTk2RTc4MTBBIiwiaWF0IjoxNjI2ODQ1NjI0fQ.fK_GHdXsQndWifJJcJw4ky-6VFIlZQow0V4uI_OnJvg',
-    'https://storage.coverr.co/videos/g5qfOaD00k1gJnw4VN9HDDfLu1voDvf01?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhcHBJZCI6IjIzQ0I1QURCMjc3QTk2RTc4MTBBIiwiaWF0IjoxNjI2ODQ1NjI0fQ.fK_GHdXsQndWifJJcJw4ky-6VFIlZQow0V4uI_OnJvg',
-    'https://storage.coverr.co/videos/Y3CuDQTQhU01OjbJIn00DdfTqB7W29Cg?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhcHBJZCI6IjIzQ0I1QURCMjc3QTk2RTc4MTBBIiwiaWF0IjoxNjI2ODQ1NjI0fQ.fK_GHdXsQndWifJJcJw4ky-6VFIlZQow0V4uI_OnJvg',
-  ],
-};
+export interface VideoModelOption {
+  id: string;
+  name: string;
+  lastModified: string;
+  downloads: number;
+  likes: number;
+}
 
-// Default videos for each style to use when search times out
-const DEFAULT_STYLE_VIDEOS: Record<string, string> = {
-  'realistic': 'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4',
-  'anime': 'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerFun.mp4',
-  'cinematic': 'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/TearsOfSteel.mp4',
-  '3d': 'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/WhatCarCanYouGetForAGrand.mp4',
-};
+interface ModelsResponse {
+  models: VideoModelOption[];
+}
 
-// Generate a deterministic index based on the prompt and style to select a video
-const getVideoIndex = (prompt: string, style: string): number => {
-  // Simple hash function to convert the prompt to a number
-  let hash = 0;
-  for (let i = 0; i < prompt.length; i++) {
-    hash = ((hash << 5) - hash) + prompt.charCodeAt(i);
-    hash |= 0; // Convert to 32bit integer
+export const fetchVideoModels = async (): Promise<VideoModelOption[]> => {
+  const response = await fetch('/api/video/models');
+  const data = (await response.json().catch(() => null)) as ModelsResponse | ({ error: string } & Partial<ModelsResponse>) | null;
+
+  if (!response.ok) {
+    const message = data && typeof data === 'object' && data !== null && 'error' in data && typeof data.error === 'string'
+      ? data.error
+      : 'Failed to load models';
+    throw new Error(message);
   }
-  
-  // Ensure positive value
-  hash = Math.abs(hash);
-  
-  // Get available videos for the specified style
-  const videos = STYLE_VIDEO_URLS[style] || STYLE_VIDEO_URLS['realistic'];
-  
-  // Return index between 0 and videos.length-1
-  return hash % videos.length;
+
+  if (!data || !('models' in data) || !Array.isArray(data.models)) {
+    throw new Error('Unable to parse models response');
+  }
+
+  return data.models;
 };
 
-// Store generation statuses in session storage
-const getStoredStatuses = (): Record<string, GenerationStatus> => {
-  if (typeof window === 'undefined') return {};
-  
-  const stored = sessionStorage.getItem('videoGenerationStatuses');
-  return stored ? JSON.parse(stored) : {};
-};
-
-const setStoredStatus = (id: string, status: GenerationStatus): void => {
-  if (typeof window === 'undefined') return;
-  
-  const statuses = getStoredStatuses();
-  statuses[id] = status;
-  sessionStorage.setItem('videoGenerationStatuses', JSON.stringify(statuses));
-};
-
-// Generate a unique ID
-const generateId = (): string => {
-  return Date.now().toString(36) + Math.random().toString(36).substring(2);
-};
-
-// Simulate searching for video directly
-const searchForVideo = async (prompt: string, style: string, timeoutMs = 10000): Promise<string> => {
-  console.log(`Searching for video with prompt: "${prompt}" and style: ${style}`);
-  
-  return new Promise((resolve) => {
-    // Set a timeout to resolve with default style video if search takes too long
-    const timeoutId = setTimeout(() => {
-      console.log(`Search timed out after ${timeoutMs}ms, using default ${style} video`);
-      resolve(DEFAULT_STYLE_VIDEOS[style] || DEFAULT_STYLE_VIDEOS['realistic']);
-    }, timeoutMs);
-    
-    // Simulate video search with random completion time (1-12 seconds)
-    const searchTime = Math.random() * 12000; // Random time between 0-12 seconds
-    
-    setTimeout(() => {
-      // If this executes before the timeout, we "found" a matching video
-      if (searchTime < timeoutMs) {
-        clearTimeout(timeoutId);
-        
-        // Get a video based on prompt and style
-        const videoIndex = getVideoIndex(prompt, style);
-        const videos = STYLE_VIDEO_URLS[style] || STYLE_VIDEO_URLS['realistic'];
-        const videoUrl = videos[videoIndex];
-        
-        console.log(`Found matching video in ${searchTime / 1000}s: ${videoUrl}`);
-        resolve(videoUrl);
-      }
-      // If this executes after the timeout, the timeout handler already resolved with default video
-    }, searchTime);
+export const generateVideo = async (params: VideoGenerationParams): Promise<VideoGenerationResult> => {
+  const response = await fetch('/api/video/generate', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(params),
   });
-};
 
-// Simulate video generation/fetching process
-export const generateVideo = async (params: VideoGenerationParams): Promise<string> => {
-  console.log('Video generation parameters:', params);
-  
-  // Create a unique ID for this generation
-  const id = generateId();
-  
-  // Store initial status
-  const initialStatus: GenerationStatus = {
-    id,
-    status: 'pending',
-    progress: 0,
-  };
-  setStoredStatus(id, initialStatus);
-  
-  // Start "processing" in the background
-  setTimeout(() => {
-    simulateProcessing(id, params);
-  }, 500);
-  
-  return id;
-};
+  const data = (await response.json().catch(() => null)) as VideoGenerationResult | ({ error: string } & Partial<VideoGenerationResult>) | null;
 
-// Simulate the video processing workflow
-const simulateProcessing = (id: string, params: VideoGenerationParams): void => {
-  // Update to processing state
-  const processingStatus: GenerationStatus = {
-    id,
-    status: 'processing',
-    progress: 10,
-  };
-  setStoredStatus(id, processingStatus);
-  
-  // Start the video search process
-  (async () => {
-    try {
-      // Simulate progress updates while searching
-      let progress = 10;
-      const progressInterval = setInterval(() => {
-        progress += 5;
-        if (progress >= 95) {
-          clearInterval(progressInterval);
-          progress = 95;
-        }
-        
-        const updatedStatus: GenerationStatus = {
-          id,
-          status: 'processing',
-          progress,
-        };
-        setStoredStatus(id, updatedStatus);
-      }, 500);
-      
-      // Search for video with 10-second timeout
-      const videoUrl = await searchForVideo(params.prompt, params.style);
-      
-      // Clear the progress interval
-      clearInterval(progressInterval);
-      
-      // Mark as completed
-      const completedStatus: GenerationStatus = {
-        id,
-        status: 'completed',
-        progress: 100,
-        result: videoUrl,
-      };
-      setStoredStatus(id, completedStatus);
-    } catch (error) {
-      console.error('Error during video search:', error);
-      
-      // Mark as failed
-      const failedStatus: GenerationStatus = {
-        id,
-        status: 'failed',
-        progress: 100,
-        error: 'Failed to find a matching video. Please try again.',
-      };
-      setStoredStatus(id, failedStatus);
-    }
-  })();
-};
-
-// Get the status of a generation by ID
-export const getGenerationStatus = async (id: string): Promise<GenerationStatus> => {
-  const statuses = getStoredStatuses();
-  const status = statuses[id];
-  
-  if (!status) {
-    throw new Error(`Generation with ID ${id} not found`);
+  if (!response.ok) {
+    const message = data && typeof data === 'object' && data !== null && 'error' in data && typeof data.error === 'string'
+      ? data.error
+      : 'Failed to generate video';
+    throw new Error(message);
   }
-  
-  return status;
-};
 
-// Reset all statuses (for testing)
-export const resetGenerationStatuses = (): void => {
-  if (typeof window === 'undefined') return;
-  sessionStorage.removeItem('videoGenerationStatuses');
-};
+  if (!data || typeof data !== 'object' || !('videoUrl' in data) || typeof data.videoUrl !== 'string') {
+    throw new Error('Invalid response from video generation service');
+  }
 
-// Function for connecting to distributed network
-export const connectToDistributedNetwork = async () => {
-  // Mock response for testing
-  return {
-    status: 'connected',
-    provider: 'Mock API with real videos',
-    nodes: 5
-  };
-}; 
+  return data as VideoGenerationResult;
+};

--- a/src/pages/api/video/generate.ts
+++ b/src/pages/api/video/generate.ts
@@ -1,0 +1,254 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+interface GenerateRequestBody {
+  prompt?: string;
+  modelId?: string;
+  duration?: number;
+  resolution?: string;
+  fps?: number;
+}
+
+interface GenerateResponseBody {
+  videoUrl: string;
+  modelId: string;
+  duration?: number;
+}
+
+const HF_INFERENCE_URL = 'https://api-inference.huggingface.co/models';
+
+const clampDuration = (value: number) => {
+  if (Number.isNaN(value)) {
+    return 60;
+  }
+  return Math.max(1, Math.min(300, Math.round(value)));
+};
+
+const clampFps = (value: number | undefined) => {
+  if (typeof value !== 'number' || Number.isNaN(value)) {
+    return 24;
+  }
+  return Math.max(1, Math.min(60, Math.round(value)));
+};
+
+const resolutionToDimensions = (resolution: string | undefined) => {
+  if (resolution === '480p') {
+    return { width: 854, height: 480 };
+  }
+  if (resolution === '1080p') {
+    return { width: 1920, height: 1080 };
+  }
+  return { width: 1280, height: 720 };
+};
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const extractVideoFromJson = (
+  payload: unknown
+): { video: string; mimeType?: string } | null => {
+  if (!payload || typeof payload !== 'object') {
+    return null;
+  }
+
+  const record = payload as Record<string, unknown>;
+
+  if (typeof record.video === 'string') {
+    const mimeType = typeof record.mime_type === 'string' ? record.mime_type : undefined;
+    return { video: record.video, mimeType };
+  }
+
+  if (typeof record.generated_video === 'string') {
+    return { video: record.generated_video, mimeType: typeof record.mime_type === 'string' ? record.mime_type : undefined };
+  }
+
+  if (Array.isArray(record.videos)) {
+    for (const item of record.videos) {
+      const found = extractVideoFromJson(item);
+      if (found) {
+        return found;
+      }
+    }
+  }
+
+  if (Array.isArray(record.data)) {
+    for (const item of record.data) {
+      const found = extractVideoFromJson(item);
+      if (found) {
+        return found;
+      }
+    }
+  }
+
+  for (const value of Object.values(record)) {
+    const found = extractVideoFromJson(value);
+    if (found) {
+      return found;
+    }
+  }
+
+  return null;
+};
+
+const normaliseVideoData = (video: string, mimeType?: string) => {
+  const trimmed = video.trim();
+  if (trimmed.startsWith('data:')) {
+    return trimmed;
+  }
+  if (trimmed.startsWith('http://') || trimmed.startsWith('https://')) {
+    return trimmed;
+  }
+  const candidate = trimmed.replace(/\s+/g, '');
+  const base64Pattern = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
+  if (base64Pattern.test(candidate)) {
+    const prefix = mimeType && mimeType.startsWith('video/') ? mimeType : 'video/mp4';
+    return `data:${prefix};base64,${candidate}`;
+  }
+  return trimmed;
+};
+
+const requestModelInference = async (url: string, token: string, body: string) => {
+  let attempt = 0;
+  const maxAttempts = 60;
+  while (attempt < maxAttempts) {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+        Accept: 'application/json,video/mp4',
+      },
+      body,
+    });
+
+    if (response.status === 503 || response.status === 202) {
+      const retryPayload = (await response.json().catch(() => null)) as
+        | { estimated_time?: number }
+        | null;
+      const waitSeconds = retryPayload && typeof retryPayload.estimated_time === 'number' && retryPayload.estimated_time > 0
+        ? retryPayload.estimated_time
+        : 5;
+      await delay(waitSeconds * 1000);
+      attempt += 1;
+      continue;
+    }
+
+    return response;
+  }
+
+  throw new Error('Timed out while waiting for Hugging Face model to generate a video');
+};
+
+export const config = {
+  api: {
+    bodyParser: {
+      sizeLimit: '4mb',
+    },
+    responseLimit: false,
+  },
+};
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<GenerateResponseBody | { error: string }>
+) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', ['POST']);
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  const { prompt, modelId, duration, resolution, fps } = req.body as GenerateRequestBody;
+
+  if (!prompt || !modelId) {
+    res.status(400).json({ error: 'Prompt and modelId are required' });
+    return;
+  }
+
+  const token = process.env.HUGGINGFACE_API_TOKEN || process.env.HF_API_TOKEN;
+
+  if (!token) {
+    res.status(500).json({ error: 'Hugging Face API token is not configured' });
+    return;
+  }
+
+  const safeDuration = typeof duration === 'number' ? clampDuration(duration) : 60;
+  const safeFps = clampFps(fps);
+  const totalFrames = Math.max(1, Math.min(18000, Math.round(safeDuration * safeFps)));
+  const dims = resolutionToDimensions(resolution);
+
+  const payload: Record<string, unknown> = {
+    inputs: {
+      prompt,
+      fps: safeFps,
+      num_frames: totalFrames,
+      max_frames: totalFrames,
+      duration_seconds: safeDuration,
+      max_duration_seconds: safeDuration,
+      width: dims.width,
+      height: dims.height,
+    },
+    parameters: {
+      max_video_duration: safeDuration,
+      num_frames: totalFrames,
+      fps: safeFps,
+      width: dims.width,
+      height: dims.height,
+    },
+    options: {
+      wait_for_model: true,
+      use_cache: false,
+    },
+  };
+
+  try {
+    const response = await requestModelInference(
+      `${HF_INFERENCE_URL}/${encodeURIComponent(modelId)}`,
+      token,
+      JSON.stringify(payload)
+    );
+
+    if (!response.ok) {
+      const errorPayload = await response.text();
+      res.status(response.status).json({ error: errorPayload || 'Video generation failed' });
+      return;
+    }
+
+    const contentType = response.headers.get('content-type') || '';
+
+    let videoUrl: string | null = null;
+
+    if (contentType.includes('application/json')) {
+      const jsonPayload = await response.json().catch(() => null);
+      if (!jsonPayload) {
+        res.status(502).json({ error: 'Received empty response from video model' });
+        return;
+      }
+      const extracted = extractVideoFromJson(jsonPayload);
+      if (!extracted) {
+        res.status(502).json({ error: 'Video payload missing in model response' });
+        return;
+      }
+      videoUrl = normaliseVideoData(extracted.video, extracted.mimeType);
+    } else {
+      const arrayBuffer = await response.arrayBuffer();
+      const buffer = Buffer.from(arrayBuffer);
+      const type = contentType && contentType.startsWith('video/') ? contentType : 'video/mp4';
+      videoUrl = `data:${type};base64,${buffer.toString('base64')}`;
+    }
+
+    if (!videoUrl) {
+      res.status(502).json({ error: 'Failed to decode video from Hugging Face response' });
+      return;
+    }
+
+    const finalDuration = typeof duration === 'number' ? clampDuration(duration) : safeDuration;
+
+    res.status(200).json({
+      videoUrl,
+      modelId,
+      duration: finalDuration,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unexpected error during video generation';
+    res.status(502).json({ error: message });
+  }
+}

--- a/src/pages/api/video/models.ts
+++ b/src/pages/api/video/models.ts
@@ -1,0 +1,140 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+type HuggingFaceModel = {
+  id: string;
+  modelId?: string;
+  lastModified?: string;
+  pipeline_tag?: string;
+  tags?: string[];
+  likes?: number;
+  downloads?: number;
+  cardData?: {
+    widgetModels?: { repoId?: string }[];
+  };
+};
+
+type ModelsResult = {
+  id: string;
+  name: string;
+  lastModified: string;
+  downloads: number;
+  likes: number;
+};
+
+type ModelsResponse = {
+  models: ModelsResult[];
+};
+
+const HF_MODELS_URL = 'https://huggingface.co/api/models';
+
+const fetchModelList = async (url: string, token: string | undefined) => {
+  const response = await fetch(url, {
+    headers: token
+      ? {
+          Authorization: `Bearer ${token}`,
+        }
+      : undefined,
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(text || 'Failed to query Hugging Face');
+  }
+
+  return (await response.json()) as HuggingFaceModel[];
+};
+
+const filterRecentModels = (models: HuggingFaceModel[]) => {
+  const seen = new Set<string>();
+  const sorted = models
+    .filter((model) => {
+      if (!model.id) {
+        return false;
+      }
+      const sourceId = model.modelId || model.id;
+      if (seen.has(sourceId)) {
+        return false;
+      }
+      const timestamp = model.lastModified;
+      if (!timestamp) {
+        return false;
+      }
+      const year = new Date(timestamp).getFullYear();
+      if (Number.isNaN(year) || year < 2025) {
+        return false;
+      }
+      seen.add(sourceId);
+      return true;
+    })
+    .sort((a, b) => {
+      const downloadsA = a.downloads ?? 0;
+      const downloadsB = b.downloads ?? 0;
+      if (downloadsA === downloadsB) {
+        const likesA = a.likes ?? 0;
+        const likesB = b.likes ?? 0;
+        return likesB - likesA;
+      }
+      return downloadsB - downloadsA;
+    });
+
+  return sorted.slice(0, 10);
+};
+
+const buildModelsResponse = (models: HuggingFaceModel[]): ModelsResult[] => {
+  return models.map((model) => ({
+    id: model.id,
+    name: model.modelId || model.id,
+    lastModified: model.lastModified || new Date().toISOString(),
+    downloads: model.downloads ?? 0,
+    likes: model.likes ?? 0,
+  }));
+};
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse<ModelsResponse | { error: string }>) {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', ['GET']);
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  const token = process.env.HUGGINGFACE_API_TOKEN || process.env.HF_API_TOKEN;
+
+  try {
+    const searchParams = new URLSearchParams({
+      pipeline_tag: 'text-to-video',
+      sort: 'downloads',
+      direction: '-1',
+      limit: '200',
+    });
+
+    let primary = await fetchModelList(`${HF_MODELS_URL}?${searchParams.toString()}`, token);
+    primary = filterRecentModels(primary);
+
+    if (primary.length < 10) {
+      const fallbackParams = new URLSearchParams({
+        search: 'long video',
+        pipeline_tag: 'text-to-video',
+        sort: 'downloads',
+        direction: '-1',
+        limit: '200',
+      });
+      const fallback = await fetchModelList(`${HF_MODELS_URL}?${fallbackParams.toString()}`, token);
+      const merged = new Map<string, HuggingFaceModel>();
+      for (const item of [...primary, ...fallback]) {
+        merged.set(item.id, item);
+      }
+      primary = filterRecentModels(Array.from(merged.values()));
+    }
+
+    if (!primary.length) {
+      res.status(404).json({ error: 'No Hugging Face video models from 2025 were found' });
+      return;
+    }
+
+    const payload = buildModelsResponse(primary);
+    res.status(200).json({ models: payload });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unexpected error while loading models';
+    res.status(502).json({ error: message });
+  }
+}

--- a/src/pages/create.tsx
+++ b/src/pages/create.tsx
@@ -1,161 +1,151 @@
-import { useState, useEffect, useRef } from 'react';
-import { useWallet } from '@/web3/WalletProvider';
-import { generateVideo, getGenerationStatus, VideoGenerationParams, GenerationStatus } from '@/api/videoGeneration';
-import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import type { ChangeEvent } from 'react';
 import Layout from '@/components/Layout';
 import WalletDropdown from '@/components/WalletDropdown';
+import { useWallet } from '@/web3/WalletProvider';
+import {
+  fetchVideoModels,
+  generateVideo,
+  VideoGenerationParams,
+  VideoGenerationResult,
+  VideoModelOption,
+} from '@/api/videoGeneration';
 
 export default function CreatePage() {
   const { connected, connectWallet, publicKey, isPhantomInstalled } = useWallet();
   const [prompt, setPrompt] = useState('');
   const [referenceImage, setReferenceImage] = useState<string | null>(null);
-  const [duration, setDuration] = useState(5);
+  const [duration, setDuration] = useState(60);
   const [resolution, setResolution] = useState<'480p' | '720p' | '1080p'>('720p');
   const [fps, setFps] = useState(24);
   const [style, setStyle] = useState('realistic');
-  
   const [isGenerating, setIsGenerating] = useState(false);
-  const [generationId, setGenerationId] = useState<string | null>(null);
-  const [status, setStatus] = useState<GenerationStatus | null>(null);
   const [error, setError] = useState<string | null>(null);
-  
-  const statusIntervalRef = useRef<NodeJS.Timeout | null>(null);
-  
-  // Display the last 8 digits of wallet address
-  const truncatedAddress = publicKey ? `${publicKey.slice(-8)}` : null;
-  
-  // Debug information
+  const [videoResult, setVideoResult] = useState<VideoGenerationResult | null>(null);
+  const [models, setModels] = useState<VideoModelOption[]>([]);
+  const [selectedModel, setSelectedModel] = useState('');
+  const [modelsLoading, setModelsLoading] = useState(false);
+  const [modelError, setModelError] = useState<string | null>(null);
+
   useEffect(() => {
-    console.log("Wallet connection status:", { connected, publicKey });
-  }, [connected, publicKey]);
-  
-  // Handle image upload
-  const handleImageUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
+    let cancelled = false;
+
+    const loadModels = async () => {
+      setModelsLoading(true);
+      setModelError(null);
+      try {
+        const list = await fetchVideoModels();
+        if (cancelled) {
+          return;
+        }
+        setModels(list);
+        setSelectedModel((current) => (current ? current : list[0]?.id ?? ''));
+      } catch (err) {
+        if (cancelled) {
+          return;
+        }
+        setModelError(err instanceof Error ? err.message : 'Failed to load models');
+      } finally {
+        if (!cancelled) {
+          setModelsLoading(false);
+        }
+      }
+    };
+
+    loadModels();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleImageUpload = (e: ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
-    if (!file) return;
-    
+    if (!file) {
+      return;
+    }
+
     const reader = new FileReader();
     reader.onload = (event) => {
       setReferenceImage(event.target?.result as string);
     };
     reader.readAsDataURL(file);
   };
-  
-  // Handle video search/fetch
+
   const handleGenerate = async () => {
-    if (!connected || !publicKey) {
-      alert('Please connect your wallet first');
+    const trimmedPrompt = prompt.trim();
+    if (!trimmedPrompt) {
+      setError('Please enter a description for the video');
       return;
     }
-    
-    if (prompt.length < 5) {
-      setError('Prompt description is too short, please enter at least 5 characters');
+    if (!selectedModel) {
+      setError('Select a Hugging Face model to continue');
       return;
     }
-    
+
     try {
       setIsGenerating(true);
       setError(null);
-      
+      setVideoResult(null);
+      const formattedPrompt = style ? `${trimmedPrompt}\nPreferred style: ${style}` : trimmedPrompt;
       const params: VideoGenerationParams = {
-        prompt,
-        referenceImage: referenceImage || undefined,
-        style,
+        prompt: formattedPrompt,
+        modelId: selectedModel,
         duration,
         resolution,
-        fps
+        fps,
       };
-      
-      // Call API to fetch a matching video
-      const id = await generateVideo(params);
-      setGenerationId(id);
-      
-      // Start polling for status updates
-      if (statusIntervalRef.current) {
-        clearInterval(statusIntervalRef.current);
-      }
-      
-      statusIntervalRef.current = setInterval(async () => {
-        try {
-          const statusData = await getGenerationStatus(id);
-          setStatus(statusData);
-          
-          // If completed or failed, stop polling
-          if (statusData.status === 'completed' || statusData.status === 'failed') {
-            if (statusIntervalRef.current) {
-              clearInterval(statusIntervalRef.current);
-              statusIntervalRef.current = null;
-            }
-            
-            setIsGenerating(false);
-            
-            if (statusData.status === 'completed') {
-              console.log('Video fetch completed:', statusData.result);
-            }
-          }
-        } catch (error) {
-          console.error('Error fetching status:', error);
-        }
-      }, 1000);
-    } catch (error) {
-      console.error('Error starting video fetch:', error);
-      setError(`Search failed: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      const result = await generateVideo(params);
+      setVideoResult(result);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Video generation failed');
+    } finally {
       setIsGenerating(false);
     }
   };
-  
-  // Clean up interval on unmount
-  useEffect(() => {
-    return () => {
-      if (statusIntervalRef.current) {
-        clearInterval(statusIntervalRef.current);
-      }
-    };
-  }, []);
-  
-  // Handle mint NFT
+
   const handleMintNFT = () => {
-    // Navigate to mint page with the generated video information
-    window.location.href = `/mint?videoUrl=${encodeURIComponent(status?.result || '')}&prompt=${encodeURIComponent(prompt)}`;
+    if (!videoResult?.videoUrl) {
+      return;
+    }
+    window.location.href = `/mint?videoUrl=${encodeURIComponent(videoResult.videoUrl)}&prompt=${encodeURIComponent(prompt)}`;
   };
 
-  // Render wallet connection section
-  const renderWalletConnection = () => {
-    if (!isPhantomInstalled) {
-      return (
-        <div className="bg-yellow-50 dark:bg-yellow-900/20 p-6 rounded-lg mb-8 text-center">
-          <p className="mb-4">Phantom wallet extension is not installed. You need Phantom wallet to use the video search feature.</p>
-          <a 
-            href="https://phantom.app/download" 
-            target="_blank" 
-            rel="noopener noreferrer"
-            className="bg-purple-600 hover:bg-purple-700 rounded-lg py-2 px-4 text-white font-bold"
-          >
-            Install Phantom Wallet
-          </a>
-          <p className="mt-2 text-xs text-gray-500">
-            Phantom is a crypto wallet reimagined for DeFi & NFTs
-          </p>
-        </div>
-      );
+  const renderModelList = () => {
+    if (modelsLoading) {
+      return <div className="text-sm text-gray-500">Loading Hugging Face models...</div>;
     }
-    
+
+    if (modelError) {
+      return <div className="text-sm text-red-500">{modelError}</div>;
+    }
+
+    if (!models.length) {
+      return <div className="text-sm text-red-500">No eligible models from 2025 were found on Hugging Face</div>;
+    }
+
+    const size = Math.min(models.length, 6) || 1;
+
     return (
-      <div className="bg-blue-50 dark:bg-blue-900/20 p-6 rounded-lg mb-8 text-center">
-        <p className="mb-4">Please connect your wallet to use the video search feature</p>
-        <button 
-          onClick={connectWallet}
-          className="bg-purple-600 hover:bg-purple-700 rounded-lg py-2 px-4 text-white font-bold"
-        >
-          Connect Wallet
-        </button>
-        <p className="mt-2 text-xs text-gray-500">
-          Connect your Phantom wallet to search and find AI-generated videos
-        </p>
-      </div>
+      <select
+        value={selectedModel}
+        onChange={(event) => setSelectedModel(event.target.value)}
+        size={size}
+        className="w-full border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-purple-500 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 shadow-sm font-medium text-sm"
+      >
+        {models.map((model) => {
+          const date = new Date(model.lastModified);
+          const formattedDate = Number.isNaN(date.getTime()) ? model.lastModified : date.toLocaleDateString();
+          return (
+            <option key={model.id} value={model.id}>
+              {`${model.name} • ${formattedDate} • ${model.downloads.toLocaleString()} downloads`}
+            </option>
+          );
+        })}
+      </select>
     );
   };
-  
+
   return (
     <Layout title="NeuralFlux - Create AI Video">
       <div className="max-w-4xl mx-auto">
@@ -163,16 +153,12 @@ export default function CreatePage() {
           <div className="flex flex-col md:flex-row justify-between items-center mb-4">
             <div className="mb-4 md:mb-0">
               <h1 className="text-xl font-bold">Generate AI Video</h1>
-              <p className="text-gray-600">
-                Generate matching videos based on your description and preferred style
-              </p>
+              <p className="text-gray-600">Generate videos aligned with your description and selected Hugging Face model</p>
             </div>
-            
-            {/* Wallet Info Bar - Show when connected */}
             {connected && publicKey ? (
               <WalletDropdown />
             ) : (
-              <button 
+              <button
                 onClick={connectWallet}
                 className="bg-purple-600 hover:bg-purple-700 rounded-lg py-2 px-4 text-white font-bold"
               >
@@ -181,169 +167,206 @@ export default function CreatePage() {
             )}
           </div>
         </div>
-        
-        {!connected ? (
-          renderWalletConnection()
-        ) : (
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-            <div className="bg-white rounded-xl shadow-md p-6">
-              <h2 className="text-xl font-bold mb-4">Generation Parameters</h2>
-              
-              <div className="mb-4">
-                <label className="block text-sm font-medium mb-2">Description</label>
-                <textarea
-                  value={prompt}
-                  onChange={(e) => setPrompt(e.target.value)}
-                  placeholder="Describe the video you want to generate..."
-                  className="w-full p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-purple-500 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 shadow-sm resize-none font-medium text-base leading-relaxed"
-                  rows={4}
-                  style={{ WebkitAppearance: 'none' }}
-                ></textarea>
-                <p className="text-xs text-gray-500 mt-1">
-                  Please be specific about the subject, setting and action in the video
-                </p>
-              </div>
-              
-              <div className="mb-4">
-                <label className="block text-sm font-medium mb-2">Reference Image (Optional)</label>
-                <div className="border-dashed border-2 border-gray-300 rounded-lg p-4 text-center">
-                  {referenceImage ? (
-                    <div className="mb-2">
-                      <img 
-                        src={referenceImage} 
-                        alt="Reference" 
-                        className="h-32 mx-auto object-contain" 
-                      />
-                      <button
-                        onClick={() => setReferenceImage(null)}
-                        className="text-red-600 text-sm mt-2"
-                      >
-                        Remove
-                      </button>
-                    </div>
-                  ) : (
-                    <div className="text-gray-500">
-                      <p className="mb-2">Drag and drop an image or click to browse</p>
-                      <label className="cursor-pointer bg-gray-200 hover:bg-gray-300 px-3 py-1 rounded-lg">
-                        Upload Image
-                        <input
-                          type="file"
-                          accept="image/*"
-                          className="hidden"
-                          onChange={handleImageUpload}
-                        />
-                      </label>
-                    </div>
-                  )}
-                </div>
-              </div>
-              
-              <div className="grid grid-cols-1 gap-4 mb-4">
-                <div>
-                  <label className="block text-sm font-medium mb-2">Video Style</label>
-                  <select
-                    value={style}
-                    onChange={(e) => setStyle(e.target.value)}
-                    className="w-full p-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-purple-500 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 shadow-sm font-medium text-base"
-                    style={{ WebkitAppearance: 'none', appearance: 'menulist', height: '42px' }}
-                  >
-                    <option value="realistic">Realistic</option>
-                    <option value="anime">Anime</option>
-                    <option value="cinematic">Cinematic</option>
-                    <option value="3d">3D Animation</option>
-                  </select>
-                </div>
-              </div>
-              
-              {error && (
-                <div className="bg-red-50 text-red-500 p-3 rounded-lg mb-4">
-                  {error}
-                </div>
-              )}
-              
+
+        {!connected && (
+          <div className="bg-blue-50 dark:bg-blue-900/20 p-6 rounded-lg mb-8 text-center">
+            <p className="mb-4">You can generate videos without connecting a wallet. Connect Phantom if you want to access Web3 features.</p>
+            {isPhantomInstalled ? (
               <button
-                onClick={handleGenerate}
-                disabled={isGenerating || prompt.length < 5}
-                className={`w-full py-3 font-bold rounded-lg ${
-                  isGenerating || prompt.length < 5
-                    ? 'bg-gray-300 text-gray-500 cursor-not-allowed'
-                    : 'bg-blue-600 hover:bg-blue-700 text-white'
-                }`}
+                onClick={connectWallet}
+                className="bg-purple-600 hover:bg-purple-700 rounded-lg py-2 px-4 text-white font-bold"
               >
-                {isGenerating ? 'Generating...' : 'Generate Video'}
+                Connect Wallet
               </button>
-            </div>
-            
-            <div className="bg-white rounded-xl shadow-md p-6">
-              <h2 className="text-xl font-bold mb-4">Preview</h2>
-              
-              {status?.status === 'completed' && status?.result ? (
-                <div>
-                  <div className="mb-4">
-                    <video 
-                      src={status.result} 
-                      controls 
-                      className="w-full rounded-lg"
-                      autoPlay
-                      loop
-                      crossOrigin="anonymous"
-                      playsInline
-                    />
-                  </div>  
-                  
-                  <div className="flex justify-center items-center mt-4">
-                    <button
-                      disabled={true}
-                      className="bg-gray-400 text-white py-2 px-4 rounded-lg font-bold relative cursor-not-allowed"
-                    >
-                      Mint as NFT
-                      <span className="absolute -top-2 -right-2 bg-yellow-500 text-xs text-white px-2 py-1 rounded-full">Coming Soon</span>
-                    </button>
-                  </div>
-                </div>
-              ) : status?.status === 'failed' ? (
-                <div className="bg-red-50 border border-red-200 rounded-lg p-6 text-center">
-                  <div className="text-red-500 text-lg mb-3">⚠️ Generation Failed</div>
-                  <p className="text-gray-700 mb-4">{status.error || 'Unable to generate a matching video. Please try again.'}</p>
-                  <button
-                    onClick={handleGenerate}
-                    className="bg-blue-600 hover:bg-blue-700 text-white py-2 px-4 rounded-lg"
-                  >
-                    Try Again
-                  </button>
-                </div>
-              ) : (
-                <div>
-                  {isGenerating ? (
-                    <div className="text-center py-8">
-                      <div className="w-16 h-16 border-4 border-blue-600 border-t-transparent rounded-full animate-spin mx-auto mb-4"></div>
-                      <p className="font-medium">Generating matching video...</p>
-                      <p className="text-sm text-gray-500 mt-2">
-                        {status?.progress && status.progress > 90 
-                          ? "If no match found in 10 seconds, will use default style video..." 
-                          : "Generating relevant video from Step-Video-TI2V open source library..."}
-                      </p>
-                      <div className="mt-4 bg-gray-100 rounded-full h-2.5 dark:bg-gray-700">
-                        <div className="bg-blue-600 h-2.5 rounded-full" style={{ width: status?.progress ? `${status.progress}%` : '0%' }}></div>
-                      </div>
-                      <p className="text-sm text-gray-500 mt-2">
-                        {status?.progress ? `${Math.round(status.progress)}%` : '0%'} completed
-                      </p>
-                    </div>
-                  ) : (
-                    <div className="bg-gray-100 h-64 rounded-lg flex items-center justify-center">
-                      <div className="text-center">
-                        <p className="text-gray-500 mb-2">No video results yet</p>
-                        <p className="text-sm text-gray-400">Enter a description and click "Generate Video" button</p>
-                      </div>
-                    </div>
-                  )}
-                </div>
-              )}
-            </div>
+            ) : (
+              <div className="flex flex-col items-center gap-2">
+                <a
+                  href="https://phantom.app/download"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="bg-purple-600 hover:bg-purple-700 rounded-lg py-2 px-4 text-white font-bold inline-block"
+                >
+                  Install Phantom Wallet
+                </a>
+                <p className="text-xs text-gray-500">Installing Phantom is optional and only required for blockchain interactions.</p>
+              </div>
+            )}
           </div>
         )}
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+          <div className="bg-white rounded-xl shadow-md p-6">
+            <h2 className="text-xl font-bold mb-4">Generation Parameters</h2>
+
+            <div className="mb-4">
+              <label className="block text-sm font-medium mb-2">Description</label>
+              <textarea
+                value={prompt}
+                onChange={(e) => setPrompt(e.target.value)}
+                placeholder="Describe the video you want to generate..."
+                className="w-full p-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-purple-500 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 shadow-sm resize-none font-medium text-base leading-relaxed"
+                rows={5}
+                style={{ WebkitAppearance: 'none' }}
+              ></textarea>
+              <p className="text-xs text-gray-500 mt-1">Add as much detail as you need. The video length can extend up to five minutes.</p>
+            </div>
+
+            <div className="mb-4">
+              <label className="block text-sm font-medium mb-2">Reference Image (Optional)</label>
+              <div className="border-dashed border-2 border-gray-300 rounded-lg p-4 text-center">
+                {referenceImage ? (
+                  <div className="mb-2">
+                    <img src={referenceImage} alt="Reference" className="h-32 mx-auto object-contain" />
+                    <button onClick={() => setReferenceImage(null)} className="text-red-600 text-sm mt-2">
+                      Remove
+                    </button>
+                  </div>
+                ) : (
+                  <div className="text-gray-500">
+                    <p className="mb-2">Drag and drop an image or click to browse</p>
+                    <label className="cursor-pointer bg-gray-200 hover:bg-gray-300 px-3 py-1 rounded-lg">
+                      Upload Image
+                      <input type="file" accept="image/*" className="hidden" onChange={handleImageUpload} />
+                    </label>
+                  </div>
+                )}
+              </div>
+            </div>
+
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-4">
+              <div>
+                <label className="block text-sm font-medium mb-2">Duration (seconds)</label>
+                <input
+                  type="number"
+                  min={1}
+                  max={300}
+                  value={duration}
+                  onChange={(event) => {
+                    const nextValue = Number(event.target.value);
+                    if (Number.isNaN(nextValue)) {
+                      setDuration(1);
+                      return;
+                    }
+                    setDuration(Math.max(1, Math.min(300, Math.round(nextValue))));
+                  }}
+                  className="w-full p-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-purple-500 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 shadow-sm"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium mb-2">Resolution</label>
+                <select
+                  value={resolution}
+                  onChange={(event) => setResolution(event.target.value as '480p' | '720p' | '1080p')}
+                  className="w-full p-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-purple-500 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 shadow-sm"
+                  style={{ WebkitAppearance: 'none', appearance: 'menulist', height: '42px' }}
+                >
+                  <option value="480p">480p</option>
+                  <option value="720p">720p</option>
+                  <option value="1080p">1080p</option>
+                </select>
+              </div>
+              <div>
+                <label className="block text-sm font-medium mb-2">Frame Rate (FPS)</label>
+                <input
+                  type="number"
+                  min={1}
+                  max={60}
+                  value={fps}
+                  onChange={(event) => {
+                    const nextValue = Number(event.target.value);
+                    if (Number.isNaN(nextValue)) {
+                      setFps(1);
+                      return;
+                    }
+                    setFps(Math.max(1, Math.min(60, Math.round(nextValue))));
+                  }}
+                  className="w-full p-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-purple-500 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 shadow-sm"
+                />
+              </div>
+            </div>
+
+            <div className="mb-4">
+              <label className="block text-sm font-medium mb-2">Video Style</label>
+              <select
+                value={style}
+                onChange={(event) => setStyle(event.target.value)}
+                className="w-full p-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-purple-500 focus:border-purple-500 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 shadow-sm font-medium text-base"
+                style={{ WebkitAppearance: 'none', appearance: 'menulist', height: '42px' }}
+              >
+                <option value="realistic">Realistic</option>
+                <option value="anime">Anime</option>
+                <option value="cinematic">Cinematic</option>
+                <option value="3d">3D Animation</option>
+              </select>
+            </div>
+
+            {error && (
+              <div className="bg-red-50 text-red-500 p-3 rounded-lg mb-4">{error}</div>
+            )}
+
+            <button
+              onClick={handleGenerate}
+              disabled={isGenerating || !prompt.trim() || !selectedModel}
+              className={`w-full py-3 font-bold rounded-lg ${
+                isGenerating || !prompt.trim() || !selectedModel
+                  ? 'bg-gray-300 text-gray-500 cursor-not-allowed'
+                  : 'bg-blue-600 hover:bg-blue-700 text-white'
+              }`}
+            >
+              {isGenerating ? 'Generating...' : 'Generate Video'}
+            </button>
+
+            <div className="mt-4">
+              <label className="block text-sm font-medium mb-2">Select a Hugging Face model</label>
+              {renderModelList()}
+            </div>
+          </div>
+
+          <div className="bg-white rounded-xl shadow-md p-6">
+            <h2 className="text-xl font-bold mb-4">Preview</h2>
+
+            {videoResult?.videoUrl ? (
+              <div>
+                <div className="mb-4">
+                  <video
+                    src={videoResult.videoUrl}
+                    controls
+                    className="w-full rounded-lg"
+                    autoPlay
+                    loop
+                    crossOrigin="anonymous"
+                    playsInline
+                  />
+                </div>
+
+                <div className="flex justify-center items-center mt-4">
+                  <button
+                    onClick={handleMintNFT}
+                    className="bg-gray-400 text-white py-2 px-4 rounded-lg font-bold relative cursor-not-allowed"
+                    disabled
+                  >
+                    Mint as NFT
+                    <span className="absolute -top-2 -right-2 bg-yellow-500 text-xs text-white px-2 py-1 rounded-full">Coming Soon</span>
+                  </button>
+                </div>
+              </div>
+            ) : isGenerating ? (
+              <div className="text-center py-8">
+                <div className="w-16 h-16 border-4 border-blue-600 border-t-transparent rounded-full animate-spin mx-auto mb-4"></div>
+                <p className="font-medium">Generating video with Hugging Face model...</p>
+                <p className="text-sm text-gray-500 mt-2">This can take a few minutes for long clips. Please keep the tab open.</p>
+              </div>
+            ) : (
+              <div className="bg-gray-100 h-64 rounded-lg flex items-center justify-center">
+                <div className="text-center">
+                  <p className="text-gray-500 mb-2">No video results yet</p>
+                  <p className="text-sm text-gray-400">Enter a description, pick a model, and click "Generate Video"</p>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
       </div>
     </Layout>
   );
-} 
+}


### PR DESCRIPTION
## Summary
- add Hugging Face polling with retry logic so video generation waits for real inference instead of returning placeholders
- normalize responses from different text-to-video models, supporting JSON payloads and mp4 binaries while preserving requested duration, fps, and resolution parameters
- clamp and translate duration, fps, and resolution inputs into model-friendly frame and dimension settings for 2025 long-form video models

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d46535d4e4832390ebf0ea7e8276a9